### PR TITLE
fix return_format on file field

### DIFF
--- a/includes/field/file.php
+++ b/includes/field/file.php
@@ -17,7 +17,6 @@ namespace sacf\field;
 class file extends base {
 
 	protected $defaults = array(
-		'save_format' => 'object',
 		'return_format' => 'array',
 		'library' => 'all',
 		'min_size' => '',


### PR DESCRIPTION
old save_format overwrote the return_format. Removing it from the defaults fixes the problem